### PR TITLE
[Bug] Fixing #4 to resolve the installation script's dir correctly.

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 require('shelljs/global');
-var realpath = require('fs').realpathSync;
+var realpath = __dirname;
 var gitRoot = exec('git rev-parse --show-toplevel').output.slice(0, -1);
 var hooksDir = gitRoot + '/.git/hooks/';
 var gitHooks = require('../lib/git-hooks');
@@ -14,7 +14,7 @@ gitHooks.forEach(function (hook) {
     mv(hookDest, hookDest + '.old');
   }
 
-  cp(realpath('./scripts/hookfile'), hookDest);
+  cp(realpath + "/hookfile", hookDest);
 
   if (test('-f', hookDest)) {
     echo(hook + ' installed successfully');


### PR DESCRIPTION
This commit fixes #4 by solving the installation directory correctly,
as it needs to resolve to the current directory. As described by
Issue #4, it does not resolve correctly when it is installed under
sub-modules.
-   modified:   scripts/install.js
- Replacing the current realpath resolution with the __dirname.
