### PR TITLE
Add git-guppy to the GulpJS website

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "git-hook",
     "git-hooks",
     "gulp",
+    "gulpplugin",
     "guppy"
   ],
   "main": "index.js",


### PR DESCRIPTION
Add git-guppy to [the list of Gulp-plugins](http://gulpjs.com/plugins/) by adding the `gulpplugin`-tag, as described in the [README](https://github.com/gulpjs/plugins/blob/master/README.md).