### PR TITLE
Handling the case where a node project is a submodule of a parent project.

### DIFF
--- a/scripts/hookfile
+++ b/scripts/hookfile
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
+var cwd = process.env.PWD || process.cwd();
 var spawn = require('child_process').spawn;
 var hookName = process.argv[1].split('/').pop();
-var hook = spawn('gulp', [hookName], { stdio: 'inherit' });
+var hook = spawn('gulp', [hookName], { stdio: 'inherit' , cwd: cwd});
 
 // catch exceptions so node doesn't exit prematurely, leaving a runaway process
 process.on('uncaughtException', function (err) {


### PR DESCRIPTION
Consider the following project structure:

```
.git/
projecta/
            .gulpfile
             node_modules/
projectb/
            (server-stuff-whatever, not a node project)
```
Running `git commit` inside project a results in `gulpfile not found` err without this change.  The parent process maintains `PWD` in the correct location.