### PR TITLE
Setup hooks in package.json

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('shelljs/global');
+var gup = require('guppy-cli');
+var async = require('async');
+var pack = require(rootApplicationPath() + '/package.json');
+
+// Install each confgured hook.
+pack['guppy-hooks'] && async.each(pack['guppy-hooks'], function (hook, next) {
+  gup.install(hook, null, next);
+});
+
+/**
+ * Get root dependent application path.
+ */
+function rootApplicationPath() {
+  return exec('git rev-parse --show-toplevel', { silent: true }).output.slice(0, -1);
+}

--- a/package.json
+++ b/package.json
@@ -33,8 +33,12 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "gulp unit"
+    "test": "gulp unit",
+    "postinstall": "node install.js"
   },
+  "guppy-hooks": [
+    "pre-commit"
+  ],
   "devDependencies": {
     "chai": "~1.9.1",
     "gulp": "^3.8.10",
@@ -44,7 +48,6 @@
     "gulp-load-plugins": "^0.10.0",
     "gulp-mocha": "^2.0.0",
     "gulp-verb": "^0.3.0",
-    "guppy-pre-commit": "^0.1.3",
     "jshint-stylish": "^0.4.0",
     "mocha": "*",
     "proxyquire": "^1.1.0",
@@ -53,6 +56,8 @@
     "verb": "~0.2.6"
   },
   "dependencies": {
+    "async": "^1.4.2",
+    "guppy-cli": "^0.3.1",
     "lodash": "^3.8.0",
     "map-stream": "0.0.5",
     "shelljs": "^0.4.0",


### PR DESCRIPTION
This pull-request aims to make it easier - and less bloating to the dependency system - to define hooks to be installed via package.json config. I've introduced a property named **guppy-hooks**, which should be fulfilled with an array of hooks to install.

I've also removed **guppy-pre-commit** dependency, so to use this new method of install.