### PR TITLE
Add possibility to have git repo root dir and gulpfile in different folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ callback) for more advanced use cases.
 gulp.task('post-checkout', ['lint']);
 ```
 
+#### Important
+
+If your *gulpfile* and *.git* directory not in the same folder, `guppy.stream` and `guppy.src` won't return related files. If you need it, you should have node GITDIR variable to be set to absolute path to *.git* parent folder. You can do it inside your gulp task or at the top of your gulpfile like this:
+
+```js
+//Set path to git repository root folder
+var path = require('path');
+var gitParentDir = path.resolve(process.cwd(), '<path to your repository root folder>');
+process.env.GITDIR = process.env.GITDIR || gitParentDir;
+```
+
 ## Writing guppy-hooks
 
 *stay tuned*

--- a/lib/get-hook.js
+++ b/lib/get-hook.js
@@ -13,8 +13,11 @@ function getIndexed() {
   return _.compact(execSync('git --git-dir=' + gitDir + ' diff --cached --name-only --diff-filter=ACM', {
     silent: true
   }).output.split('\n')
-    .map(function (url) {
-      return path.resolve(gitParentDir, url);
+    .filter(function (file) {
+      return Boolean(file);
+    })
+    .map(function (file) {
+      return path.relative(process.cwd(), path.resolve(gitParentDir, file));
     }));
 }
 

--- a/lib/get-hook.js
+++ b/lib/get-hook.js
@@ -2,14 +2,20 @@
 
 var _ = require('lodash');
 var execSync = require('shelljs').exec;
+var path = require('path');
 var stripBom = require('strip-bom');
 var map = require('map-stream');
 var hookArgs = process.env.HOOK_ARGS ? process.env.HOOK_ARGS.split('\u263a') : [];
 
 function getIndexed() {
-  return _.compact(execSync('git diff --cached --name-only --diff-filter=ACM', {
+  var gitParentDir = process.env.GITDIR || process.cwd();
+  var gitDir = path.resolve(gitParentDir, '.git');
+  return _.compact(execSync('git --git-dir=' + gitDir + ' diff --cached --name-only --diff-filter=ACM', {
     silent: true
-  }).output.split('\n'));
+  }).output.split('\n')
+    .map(function (url) {
+      return path.resolve(gitParentDir, url);
+    }));
 }
 
 function streamFromIndexed(gulp, options) {

--- a/test/guppy.tests.js
+++ b/test/guppy.tests.js
@@ -6,6 +6,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
 var proxy = require('proxyquire');
+var path = require('path');
 chai.use(require('sinon-chai'));
 
 var timesCalled = 0;
@@ -29,8 +30,10 @@ var gulp = {
 
 function mapThru(fn) { return fn; }
 
-var execSyncStub = sinon.stub();
-execSyncStub.withArgs('git diff --cached --name-only --diff-filter=ACM')
+var gitParentDir = process.env.GITDIR || process.cwd(),
+    gitDir = path.resolve(gitParentDir, '.git'),
+    execSyncStub = sinon.stub();
+execSyncStub.withArgs('git --git-dir=' + gitDir + ' diff --cached --name-only --diff-filter=ACM')
   .returns({ output: 'index.js\ntest.js' });
 execSyncStub.withArgs('git ls-files -s path')
   .returns({ output: 'some hash' });
@@ -216,7 +219,7 @@ describe('guppy', function () {
           expect(files).to.eql(['index.js', 'test.js']);
           expect(cb).to.equal('gulp done callback');
 
-          expect(execSyncStub).to.have.been.calledWith('git diff --cached --name-only --diff-filter=ACM');
+          expect(execSyncStub).to.have.been.calledWith('git --git-dir=' + gitDir + ' diff --cached --name-only --diff-filter=ACM');
 
           done();
         })('gulp done callback');
@@ -244,7 +247,7 @@ describe('guppy', function () {
           expect(files).to.eql(['index.js', 'test.js']);
           expect(cb).to.equal('gulp done callback');
 
-          expect(execSyncStub).to.have.been.calledWith('git diff --cached --name-only --diff-filter=ACM');
+          expect(execSyncStub).to.have.been.calledWith('git --git-dir=' + gitDir + ' diff --cached --name-only --diff-filter=ACM');
 
           done();
         })('gulp done callback');


### PR DESCRIPTION
Refer to this [issue](https://github.com/therealklanni/git-guppy/issues/41)

When .git and gulpfile are in different folders `guppy.src` and `guppy.stream` return empty arrays of related files.

Fixed.