### PR TITLE
Fix Git commands executed in a working directory that isn't the repository root

### DIFF
--- a/lib/get-hook.js
+++ b/lib/get-hook.js
@@ -4,7 +4,32 @@ var _ = require('lodash');
 var execSync = require('shelljs').exec;
 var stripBom = require('strip-bom');
 var map = require('map-stream');
+var fs = require('fs');
 var hookArgs = process.env.HOOK_ARGS ? process.env.HOOK_ARGS.split('\u263a') : [];
+
+function isDirectory(path) {
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return false;
+    }
+
+    throw e;
+  }
+}
+
+// git hooks set the GIT_DIR environment variable to the path of the '.git' folder, so remove it
+// if the folder doesn't exist in the current directory (allow git tools to find it themselves)
+if (process.env.GIT_DIR && !isDirectory(process.env.GIT_DIR)) {
+  delete process.env.GIT_DIR;
+
+  // hooks may also set GIT_INDEX_FILE to '.git/index', if we aren't in the directory where '.git'
+  // lives, having this set will break commands that access the index.
+  if (process.env.GIT_INDEX_FILE) {
+    delete process.env.GIT_INDEX_FILE;
+  }
+}
 
 function getIndexed() {
   return _.compact(execSync('git diff --cached --name-only --diff-filter=ACM', {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Simple git-hook integration for your gulp workflows.",
   "homepage": "https://github.com/therealklanni/git-guppy",
   "author": "Kevin Lanni (https://github.com/therealklanni)",
+  "contributors": [
+    "Marcus R. Brown (https://github.com/igetgames)"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/therealklanni/git-guppy.git"


### PR DESCRIPTION
This is an alternative to #73 that only relies on the environment variables passed down through Git hooks.

A Git hook is executed from the location of the root .git directory, and some hooks (all?) will set the GIT_DIR and GIT_INDEX_FILE variables relative to that location, instead of the working directory. In the case of a working directory or project (containing a Gulpfile with hook tasks) beneath the repository root, GIT_DIR is set to '.git' and GIT_INDEX_FILE is set to '.git/index'. These variables act as an implicit --git-dir argument that is passed to any Git commands executed from a hook. This breaks the getIndexed() and streamFromIndex() functions because '.git' doesn't exist in the working directory and so the Git commands run from these functions are unable to locate the repository root.

The approach that I've seen other software use is to detect whether the value of GIT_DIR exists as a directory relative to the working directory, and if it doesn't then remove it from the environment. Without this implicit --git-dir argument the Git commands run from hooks will autodetect the .git directory (climbing up the tree) as if they had been run from the command line.

I couldn't figure out how to add tests for this functionality since I didn't modify any functions.