### PR TITLE
Resolve root location of git repo when pwd/gulpfile is not in the root

### DIFF
--- a/lib/get-hook.js
+++ b/lib/get-hook.js
@@ -7,9 +7,12 @@ var map = require('map-stream');
 var hookArgs = process.env.HOOK_ARGS ? process.env.HOOK_ARGS.split('\u263a') : [];
 
 function getIndexed() {
+  var cdup = execSync('git rev-parse --show-cdup', { silent: true });
+  var gitRootCdPath = '';
+  if(typeof cdup!=='undefined' && typeof cdup.output!=='undefined') { gitRootCdPath=cdup.output.trim(); }
   return _.compact(execSync('git diff --cached --name-only --diff-filter=ACM', {
     silent: true
-  }).output.split('\n'));
+  }).output.split('\n').map(function(f) {return gitRootCdPath + f.trim()}));
 }
 
 function streamFromIndexed(gulp, options) {


### PR DESCRIPTION
This is a simple solution to dealing with complex repos where the gulpfile is not in the root of the git repo. This has resolved the issues for our project without resorting to adding root path variables or anything so drastic. I haven't dug into writing test cases for it (although I did confirm existing unit tests still pass).  If you think it has merit and it passes scrutiny I'd be happy to experiment with test scenarios.